### PR TITLE
docs: add J69 + convert all full-format addresses to b32 format

### DIFF
--- a/core-contributors.md
+++ b/core-contributors.md
@@ -103,6 +103,7 @@ core成员内自然演化形成的办事机构如下：（更新日期：2024.12
 🆔J66 | 元神道（机构）（联络人：老道） | ✅ | [@huikygit](https://github.com/huikygit) | J3亚夜天消巡喝超收桥使世硫耗孟贸N0FSS | 暂无 | 2026/1/8 renew (since 2025/7/18)
 🆔J67 | Bataroc | ✅ | [@Bataroc](https://github.com/Bataroc) | J3宁下元拨苗鲜杂独寸修万李一煮忧KG34L | 暂无 | 2026/1/8
 🆔J68 | Jasper | ✅ | [@Jasper](https://github.com/xiaopiao009) | j3csc8th9v839wkqxf4v3xzr2fvkjwadmnzejznd | 暂无 | 2026/6/15
+🆔J69 | 刘桂洪 | ✅ | - | j36csksz7ux0wz3xcqlhpe597053j6crjsfe7m50 | - | 2026/7/9
 
 
 TODO: 注意core id换新会有一个悖论：powh统计工作量是记在旧core id头上的，但是空投却需要执行给新core id。


### PR DESCRIPTION
## 变更内容

1. **新增 core 贡献者 J69 刘桂洪**
2. **批量转换地址格式**: 将 core-contributors.md 中所有 Full 格式（汉字）地址全部转换为 B32（纯Base32）格式
   - 涉及 67 个地址
   - 使用 jscan.jnsdao.com 上的 jvaddress.js 库完成转换
   - B32 格式更利于机器处理和批量操作

## 关于格式规范

后续统一使用 B32 格式（`j3` + 38位Base32字符，全小写）记录空投接收地址。